### PR TITLE
Improve availability checks: don't wait on exited processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "psctl"
-version = "0.6.1"
+version = "0.6.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "psctl"
-version = "0.5.0-1"
+version = "0.6.1"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psctl"
-version = "0.5.0-1"
+version = "0.6.1"
 edition = "2021"
 description = "Process Control is an operator for related processes. It runs processes as an interdependent graph."
 repository = "https://github.com/bww/psctl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psctl"
-version = "0.6.1"
+version = "0.6.0"
 edition = "2021"
 description = "Process Control is an operator for related processes. It runs processes as an interdependent graph."
 repository = "https://github.com/bww/psctl"

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,14 @@ Any number of task specifiers may be provided as arguments. Each specifier has t
     label    := /[a-zA-Z0-9]+/
     deps     := '+' <labels>
     command  := /[^=]+/
-    check    := a file:// or http(s):// url
+    check    := <scheme>://<content>
+
+READINESS CHECKS
+    Readiness checks are expressed as a URL. The following types are supported:
+
+    http(s)://...      The check passes when the URL returns 2XX
+    file://...         The check passes when the file exists
+    shell://<command>  The check passes when the command exists with status 0
 
 EXAMPLE
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[clap(
+  author, version,
+  about = "Process Control is an operator for interdependent processes.
+https://crates.io/crates/psctl",
+  long_about = None,
+  after_help = "EXAMPLES:
+
+    $ psctl 'a: echo A' 'b: echo B=file:///tmp/file' 'c +a,b: echo C'"
+)]
+pub struct Options {
+  #[clap(long, help="Enable debugging mode")]
+  pub debug: bool,
+  #[clap(long, help="Enable verbose output")]
+  pub verbose: bool,
+  #[clap(long, help="Load process specifiers from a taskfile")]
+  pub file: Option<String>,
+  #[clap(
+    help_heading="SPECIFIERS",
+    help="Task specifiers to run and manage. When a taskfile is provided, it is preferred over specifiers provided on the command line.
+
+Any number of task specifiers may be provided as arguments. Each specifier has the following form:
+
+    spec     := <label> [<deps>]: <command>[=<check>]
+    labels   := <label1> [... <labelN>]
+    label    := /[a-zA-Z0-9]+/
+    deps     := '+' <labels>
+    command  := /[^=]+/
+    check    := a file:// or http(s):// url
+
+EXAMPLE
+
+    $ psctl 'a: echo A' 'b: echo B=file:///tmp/file' 'c +a,b: echo C'
+")]
+  pub specs: Vec<String>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ READINESS CHECKS
 
     http(s)://...      The check passes when the URL returns 2XX
     file://...         The check passes when the file exists
-    shell://<command>  The check passes when the command exists with status 0
+    shell://<command>  The check passes when the command exits with status 0
 
 EXAMPLE
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ mod runner;
 mod error;
 mod config;
 
-
 #[tokio::main]
 async fn main() {
   match cmd().await {
@@ -44,6 +43,12 @@ async fn cmd() -> Result<i32, error::Error> {
     }
     procs
   };
+
+  if opts.debug {
+    let name = env!("CARGO_PKG_NAME");
+    let version = env!("CARGO_PKG_VERSION");
+    eprintln!("{}", &format!("====> {} {}, at your service", name, version).bold().cyan());
+  }
 
   if procs.is_empty() {
     Ok(0) // nothing to do

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::process;
 
 use tokio::sync::mpsc;
 use futures::executor;
+
 use clap::Parser;
 use serde::{Serialize, Deserialize};
 use colored::Colorize;
@@ -10,43 +11,8 @@ use colored::Colorize;
 mod waiter;
 mod runner;
 mod error;
+mod config;
 
-#[derive(Parser, Debug, Clone)]
-#[clap(
-  author, version,
-  about = "Process Control is an operator for interdependent processes.
-https://crates.io/crates/psctl",
-  long_about = None,
-  after_help = "EXAMPLES:
-
-    $ psctl 'a: echo A' 'b: echo B=file:///tmp/file' 'c +a,b: echo C'"
-)]
-pub struct Options {
-  #[clap(long, help="Enable debugging mode")]
-  pub debug: bool,
-  #[clap(long, help="Enable verbose output")]
-  pub verbose: bool,
-  #[clap(long, help="Load process specifiers from a taskfile")]
-  pub file: Option<String>,
-  #[clap(
-    help_heading="SPECIFIERS",
-    help="Task specifiers to run and manage. When a taskfile is provided, it is preferred over specifiers provided on the command line.
-
-Any number of task specifiers may be provided as arguments. Each specifier has the following form:
-
-    spec     := <label> [<deps>]: <command>[=<check>]
-    labels   := <label1> [... <labelN>]
-    label    := /[a-zA-Z0-9]+/
-    deps     := '+' <labels>
-    command  := /[^=]+/
-    check    := a file:// or http(s):// url
-
-EXAMPLE
-
-    $ psctl 'a: echo A' 'b: echo B=file:///tmp/file' 'c +a,b: echo C'
-")]
-  pub specs: Vec<String>,
-}
 
 #[tokio::main]
 async fn main() {
@@ -60,7 +26,7 @@ async fn main() {
 }
 
 async fn cmd() -> Result<i32, error::Error> {
-  let opts = Options::parse();
+  let opts = config::Options::parse();
   let (tx, mut rx) = mpsc::channel(1);
 
   ctrlc::set_handler(move || {
@@ -82,7 +48,7 @@ async fn cmd() -> Result<i32, error::Error> {
   if procs.is_empty() {
     Ok(0) // nothing to do
   }else{
-    Ok(runner::Pod::new(procs).exec(&mut rx).await?)
+    Ok(runner::Pod::new(opts, procs).exec(&mut rx).await?)
   }
 }
 

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -42,6 +42,7 @@ pub enum Error {
   ExecError(ExecError),
   DependencyError(DependencyError),
   CanceledError,
+  NeverInitializedError(String),
 }
 
 impl From<io::Error> for Error {
@@ -76,6 +77,7 @@ impl fmt::Display for Error {
       Self::ExecError(err) => err.fmt(f),
       Self::DependencyError(err) => err.fmt(f),
       Self::CanceledError => write!(f, "Canceled"),
+      Self::NeverInitializedError(key) => write!(f, "{}: exited before it became available", key),
     }
   }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -71,16 +71,16 @@ impl Pod {
           _   = rx.recv()   => Err(error::Error::CanceledError),
           _   = proc.wait() => Err(error::Error::NeverInitializedError(spec.key().to_owned())),
           res = waiter::wait(checks, spec.wait) =>  match res {
-            Ok(_)    => Ok(spec.key()),
+            Ok(_)    => Ok((spec.key(), false)),
             Err(err) => Err(err.into()),
           }
         }
       } else {
-        Ok(spec.key()) // immediately available if we have no checks
+        Ok((spec.key(), true)) // immediately available if we have no checks
       };
       pset.push((spec, proc));
       match res {
-        Ok(key)  => if self.opts.verbose { eprintln!("{}", &format!("----> {}: available", key).bold()) },
+        Ok((key, dflt))  => if !dflt || self.opts.verbose { eprintln!("{}", &format!("----> {}: available", key).bold()) },
         Err(err) => return Err(err),
       }
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -23,16 +23,19 @@ use nix::sys::signal;
 use nix::sys::signal::Signal;
 
 use crate::waiter;
+use crate::config;
 
 type Result<T> = result::Result<T, error::Error>;
 
 pub struct Pod {
+  opts:  config::Options,
   procs: Vec<Process>,
 }
 
 impl Pod {
-  pub fn new(procs: Vec<Process>) -> Pod {
+  pub fn new(opts: config::Options, procs: Vec<Process>) -> Pod {
     Pod{
+      opts: opts, 
       procs: procs,
     }
   }
@@ -77,7 +80,7 @@ impl Pod {
       };
       pset.push((spec, proc));
       match res {
-        Ok(key)  => eprintln!("{}", &format!("----> {}: available", key).bold()),
+        Ok(key)  => if self.opts.verbose { eprintln!("{}", &format!("----> {}: available", key).bold()) },
         Err(err) => return Err(err),
       }
     }

--- a/src/waiter/mod.rs
+++ b/src/waiter/mod.rs
@@ -41,10 +41,7 @@ where
   let wait = time::Duration::from_secs(1);
   loop {
     let before = SystemTime::now();
-    if match func(url.to_string(), deadline.duration_since(SystemTime::now())?).await {
-      Ok(res) => res,
-      Err(_)  => false, // maybe log this?
-    } {
+    if (func(url.to_string(), deadline.duration_since(SystemTime::now())?).await).unwrap_or_default() {
       return Ok(()); // success
     }
     let after = SystemTime::now();

--- a/test/available.yaml
+++ b/test/available.yaml
@@ -1,0 +1,13 @@
+version: 1
+tasks:
+  -
+    name: a
+    run: sleep 3 && echo "A"
+
+  -
+    name: b
+    run: sleep 3 && echo "B"
+
+  -
+    name: c
+    run: sleep 3 && echo "C"

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -1,17 +1,18 @@
 version: 1
 tasks:
   -
+    name: d
+    run: sleep 4 && echo "D"
+    wait: 2s
+    checks:
+      - shell:echo "first"
+      - shell:echo "second" && exit 1
+
+  -
     name: e
     run: sleep 3 && echo "E"
     checks:
       - shell:echo "E is ready; let's go"
-
-  -
-    name: d
-    run: sleep 4 && echo "D"
-    checks:
-      - shell:echo "first"
-      - shell:echo "second" && exit 1
 
   -
     name: a

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -1,10 +1,17 @@
 version: 1
 tasks:
   -
-    name: d
-    run: sleep 10 && echo "D"
+    name: e
+    run: sleep 3 && echo "E"
     checks:
-      - shell:echo "check" && exit 1
+      - shell:echo "E is ready; let's go"
+
+  -
+    name: d
+    run: sleep 4 && echo "D"
+    checks:
+      - shell:echo "first"
+      - shell:echo "second" && exit 1
 
   -
     name: a

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -1,18 +1,18 @@
 version: 1
 tasks:
   -
+    name: e
+    run: sleep 3 && echo "E"
+    checks:
+      - shell:echo "E is ready; let's go"
+
+  -
     name: d
     run: sleep 4 && echo "D"
     wait: 2s
     checks:
       - shell:echo "first"
       - shell:echo "second" && exit 1
-
-  -
-    name: e
-    run: sleep 3 && echo "E"
-    checks:
-      - shell:echo "E is ready; let's go"
 
   -
     name: a


### PR DESCRIPTION
If a process has exited, it will never become available, we can stop checking. This is always considered an error because the process never initialized.