### PR TITLE
Adding support for per-process environment definition

### DIFF
--- a/test/env.yaml
+++ b/test/env.yaml
@@ -1,0 +1,17 @@
+version: 1
+tasks:
+  -
+    name: a
+    env:
+      MESSAGE: Hello, there. I'm your message.
+    run: sleep 2 && echo "$MESSAGE"
+    checks:
+      - shell:echo "A is ready"
+
+  -
+    name: b
+    env:
+      MESSAGE: Different process, different message.
+    run: sleep 1 && echo "$MESSAGE"
+    checks:
+      - shell:echo "B is ready"


### PR DESCRIPTION
Previously this was possible by packing it into the `run` command, but an explicit section is preferable.